### PR TITLE
Bump pre-commit hook versions and update gatekeeper version to v3.19.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.97.3
+    rev: v1.99.0
     hooks:
       - id: terraform_fmt
 
@@ -29,7 +29,7 @@ repos:
       - id: terraform_docs
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.368
+    rev: 3.2.408
     hooks:
       - id: checkov
         verbose: true

--- a/regional/README.md
+++ b/regional/README.md
@@ -12,7 +12,7 @@ No requirements.
 | Name | Version |
 |------|---------|
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.17.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.35.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.36.0 |
 
 ## Modules
 
@@ -44,7 +44,7 @@ No requirements.
 | <a name="input_controller_manager_resources_limits_memory"></a> [controller\_manager\_resources\_limits\_memory](#input\_controller\_manager\_resources\_limits\_memory) | The memory limit for the controller manager container | `string` | `"256Mi"` | no |
 | <a name="input_controller_manager_resources_requests_cpu"></a> [controller\_manager\_resources\_requests\_cpu](#input\_controller\_manager\_resources\_requests\_cpu) | The CPU request for the controller manager container | `string` | `"10m"` | no |
 | <a name="input_controller_manager_resources_requests_memory"></a> [controller\_manager\_resources\_requests\_memory](#input\_controller\_manager\_resources\_requests\_memory) | The memory request for the controller manager container | `string` | `"32Mi"` | no |
-| <a name="input_gatekeeper_version"></a> [gatekeeper\_version](#input\_gatekeeper\_version) | The version to install, this is used for the chart as well as the image tag | `string` | `"v3.18.2"` | no |
+| <a name="input_gatekeeper_version"></a> [gatekeeper\_version](#input\_gatekeeper\_version) | The version to install, this is used for the chart as well as the image tag | `string` | `"v3.19.1"` | no |
 | <a name="input_node_location"></a> [node\_location](#input\_node\_location) | The zone in which the cluster's nodes should be located. If not specified, the cluster's nodes are located across zones in the region | `string` | `null` | no |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | The number of replicas to run | `number` | `1` | no |
 

--- a/regional/variables.tf
+++ b/regional/variables.tf
@@ -64,7 +64,7 @@ variable "controller_manager_resources_requests_memory" {
 variable "gatekeeper_version" {
   description = "The version to install, this is used for the chart as well as the image tag"
   type        = string
-  default     = "v3.18.2"
+  default     = "v3.19.1"
 }
 
 variable "node_location" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated pre-commit checks to use newer versions for improved reliability.
- **Documentation**
  - Updated provider and default Gatekeeper version information in documentation.
- **New Features**
  - Default Gatekeeper version updated to v3.19.1 for new deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->